### PR TITLE
Add video title

### DIFF
--- a/androidenhancedvideoplayer/src/androidTest/java/com/profusion/androidenhancedvideoplayer/test/PlayerControlsTest.kt
+++ b/androidenhancedvideoplayer/src/androidTest/java/com/profusion/androidenhancedvideoplayer/test/PlayerControlsTest.kt
@@ -4,6 +4,7 @@ import DefaultPlayerControls
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import org.junit.Rule
 import org.junit.Test
@@ -153,5 +154,18 @@ class PlayerControlsTest {
         composeTestRule.onNodeWithTag("SettingsControlsParent").assertDoesNotExist()
         composeTestRule.onNodeWithTag("SettingsButton").performClick()
         composeTestRule.onNodeWithTag("SettingsControlsParent").assertIsDisplayed()
+    }
+
+    @Test
+    fun playerControls_WhenHasTitleShouldDisplayTitle() {
+        val title = "My Video Title"
+
+        composeTestRule.setContent {
+            DefaultPlayerControls(
+                title = title
+            )
+        }
+
+        composeTestRule.onNodeWithText(title).assertIsDisplayed()
     }
 }

--- a/androidenhancedvideoplayer/src/androidTest/java/com/profusion/androidenhancedvideoplayer/test/utils/DefaultPlayerControls.kt
+++ b/androidenhancedvideoplayer/src/androidTest/java/com/profusion/androidenhancedvideoplayer/test/utils/DefaultPlayerControls.kt
@@ -5,6 +5,7 @@ import com.profusion.androidenhancedvideoplayer.components.playerOverlay.Setting
 
 @Composable
 fun DefaultPlayerControls(
+    title: String? = null,
     isVisible: Boolean = true,
     isPlaying: Boolean = false,
     isFullScreen: Boolean = false,
@@ -19,6 +20,7 @@ fun DefaultPlayerControls(
     settingsControlsCustomization: SettingsControlsCustomization = SettingsControlsCustomization()
 ) {
     PlayerControls(
+        title = title,
         isVisible = isVisible,
         isPlaying = isPlaying,
         isFullScreen = isFullScreen,

--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/EnhancedVideoPlayer.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/EnhancedVideoPlayer.kt
@@ -67,6 +67,9 @@ fun EnhancedVideoPlayer(
     var speed by remember { mutableStateOf(exoPlayer.playbackParameters.speed) }
 
     val isFullScreen = configuration.orientation == ORIENTATION_LANDSCAPE
+    var title by remember {
+        mutableStateOf(exoPlayer.currentMediaItem?.mediaMetadata?.displayTitle?.toString())
+    }
 
     DisposableEffect(context) {
         val listener = object : Player.Listener {
@@ -81,6 +84,10 @@ fun EnhancedVideoPlayer(
             override fun onPlaybackParametersChanged(playbackParameters: PlaybackParameters) {
                 speed = playbackParameters.speed
                 super.onPlaybackParametersChanged(playbackParameters)
+            }
+            override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+                title = mediaItem?.mediaMetadata?.displayTitle?.toString()
+                super.onMediaItemTransition(mediaItem, reason)
             }
         }
         exoPlayer.addListener(listener)
@@ -113,6 +120,7 @@ fun EnhancedVideoPlayer(
             }
         )
         PlayerControls(
+            title = title,
             isVisible = isControlsVisible,
             isPlaying = isPlaying,
             isFullScreen = isFullScreen,

--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/PlayerControls.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/PlayerControls.kt
@@ -18,6 +18,7 @@ class ControlsCustomization(
 
 @Composable
 fun PlayerControls(
+    title: String? = null,
     isVisible: Boolean,
     isPlaying: Boolean,
     isFullScreen: Boolean,
@@ -35,7 +36,11 @@ fun PlayerControls(
     PlayerControlsScaffold(
         modifier = modifier.testTag("PlayerControlsParent"),
         isVisible = isVisible,
-        topContent = { /* TODO */ },
+        topContent = {
+            TopControls(
+                title = title
+            )
+        },
         bottomContent = {
             BottomControls(
                 isFullScreen = isFullScreen,
@@ -63,6 +68,7 @@ fun PlayerControls(
 @Composable
 private fun PreviewPlayerControls() {
     PlayerControls(
+        title = "Really long title that should be truncated",
         isVisible = true,
         isPlaying = true,
         hasEnded = false,

--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/TopControls.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/TopControls.kt
@@ -1,0 +1,49 @@
+package com.profusion.androidenhancedvideoplayer.components.playerOverlay
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import com.profusion.androidenhancedvideoplayer.styling.Dimensions
+
+@Composable
+fun TopControls(
+    title: String? = null,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Min)
+            .padding(Dimensions.large)
+    ) {
+        if (title != null) {
+            Text(
+                text = title,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.titleLarge.copy(
+                    color = Color.White
+                ),
+                modifier = Modifier.align(Alignment.TopStart)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun TopControlsPreview() {
+    TopControls(
+        title = "Title"
+    )
+}


### PR DESCRIPTION
## Description

- Add a top bar that has the video title

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [x] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

- You can test using the preview
- Or you can change the code to set the mediaItem with a mocked title

```kotlin
                setMediaItem(
                    MediaItem.Builder()
                        .setUri(Uri.parse(mainPackagePath + resourceId.toString()))
                        .setMediaMetadata(
                            MediaMetadata.Builder()
                                .setDisplayTitle("My video title")
                                .build()
                        )
                        .build()
                )
```

## Visual reference

![image](https://github.com/profusion/android-enhanced-video-player/assets/35314270/e3ce44b5-d327-4476-974f-038404c8a26e)
