### PR TITLE
Make SpeedIcon and CheckIcon change color according to theme

### DIFF
--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/PlayerIcons.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/PlayerIcons.kt
@@ -1,8 +1,10 @@
 package com.profusion.androidenhancedvideoplayer.components.playerOverlay
 
-import androidx.compose.foundation.Image
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -10,87 +12,97 @@ import com.profusion.androidenhancedvideoplayer.R
 
 @Composable
 fun PreviousIcon() {
-    Image(
+    Icon(
         painter = painterResource(id = R.drawable.ic_skip_previous),
         contentDescription = stringResource(id = R.string.controls_previous_description),
+        tint = Color.White,
         modifier = Modifier.testTag("PreviousIcon")
     )
 }
 
 @Composable
 fun PlayIcon() {
-    Image(
+    Icon(
         painter = painterResource(id = R.drawable.ic_play),
         contentDescription = stringResource(id = R.string.controls_play_description),
+        tint = Color.White,
         modifier = Modifier.testTag("PlayIcon")
     )
 }
 
 @Composable
 fun PauseIcon() {
-    Image(
+    Icon(
         painter = painterResource(id = R.drawable.ic_pause),
         contentDescription = stringResource(id = R.string.controls_pause_description),
+        tint = Color.White,
         modifier = Modifier.testTag("PauseIcon")
     )
 }
 
 @Composable
 fun NextIcon() {
-    Image(
+    Icon(
         painter = painterResource(id = R.drawable.ic_skip_next),
         contentDescription = stringResource(R.string.controls_next_description),
+        tint = Color.White,
         modifier = Modifier.testTag("NextIcon")
     )
 }
 
 @Composable
 fun ReplayIcon() {
-    Image(
+    Icon(
         painter = painterResource(id = R.drawable.ic_replay),
         contentDescription = stringResource(id = R.string.controls_replay_description),
+        tint = Color.White,
         modifier = Modifier.testTag("ReplayIcon")
     )
 }
 
 @Composable
 fun FullScreenIcon() {
-    Image(
+    Icon(
         painter = painterResource(id = R.drawable.ic_fullscreen),
         contentDescription = stringResource(R.string.controls_fullscreen_description),
+        tint = Color.White,
         modifier = Modifier.testTag("FullScreenIcon")
     )
 }
 
 @Composable
 fun ExitFullScreenIcon() {
-    Image(
+    Icon(
         painter = painterResource(id = R.drawable.ic_exit_fullscreen),
         contentDescription = stringResource(R.string.controls_exit_fullscreen_description),
+        tint = Color.White,
         modifier = Modifier.testTag("ExitFullScreenIcon")
     )
 }
 
 @Composable
 fun SettingsIcon() {
-    Image(
+    Icon(
         painter = painterResource(id = R.drawable.ic_settings),
+        tint = Color.White,
         contentDescription = stringResource(R.string.controls_settings_description)
     )
 }
 
 @Composable
 fun SpeedIcon() {
-    Image(
+    Icon(
         painter = painterResource(id = R.drawable.ic_speed),
+        tint = MaterialTheme.colorScheme.onPrimaryContainer,
         contentDescription = stringResource(R.string.settings_speed_description)
     )
 }
 
 @Composable
 fun CheckIcon(modifier: Modifier = Modifier) {
-    Image(
+    Icon(
         painter = painterResource(id = R.drawable.ic_check),
+        tint = MaterialTheme.colorScheme.onPrimaryContainer,
         contentDescription = stringResource(R.string.settings_check_description),
         modifier = modifier
     )


### PR DESCRIPTION
## Description

- Make SpeedIcon and CheckIcon change color according to theme
  - [onPrimaryContainer reference](https://m3.material.io/styles/color/the-color-system/color-roles)

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

- Open the settings menu

## Visual reference

https://github.com/profusion/android-enhanced-video-player/assets/35314270/9d38a3a0-a901-4e87-82fd-e248e1f9171a

