### PR TITLE
Add flags to disable controls and gesture

### DIFF
--- a/androidenhancedvideoplayer/src/androidTest/java/com/profusion/androidenhancedvideoplayer/test/EnhancedVideoPlayerTest.kt
+++ b/androidenhancedvideoplayer/src/androidTest/java/com/profusion/androidenhancedvideoplayer/test/EnhancedVideoPlayerTest.kt
@@ -34,6 +34,25 @@ class EnhancedVideoPlayerTest {
     }
 
     @Test
+    fun enhancedVideoPlayer_WhenClickingOnVideoShouldNotShowControlsWhenControlsDisabled() {
+        composeTestRule.setContent {
+            EnhancedVideoPlayer(
+                resourceId = R.raw.login_screen_background,
+                disableControls = true
+            )
+        }
+
+        composeTestRule.onNodeWithTag("PlayerControlsParent").assertDoesNotExist()
+
+        composeTestRule.onNodeWithTag("VideoPlayerParent")
+            .assertIsDisplayed()
+            .performClick()
+
+        composeTestRule.onNodeWithTag("PlayerControlsParent", useUnmergedTree = true)
+            .assertDoesNotExist()
+    }
+
+    @Test
     fun enhancedVideoPlayer_WhenDoubleClickHappenOnTheFirstHalfOfScreenVideoShouldShowRewindIcon() {
         composeTestRule.setContent {
             EnhancedVideoPlayer(

--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/EnhancedVideoPlayer.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/EnhancedVideoPlayer.kt
@@ -57,6 +57,7 @@ fun EnhancedVideoPlayer(
     enableImmersiveMode: Boolean = true,
     playImmediately: Boolean = true,
     soundOff: Boolean = true,
+    disableControls: Boolean = false,
     currentTimeTickInMs: Long = CURRENT_TIME_TICK_IN_MS,
     controlsCustomization: ControlsCustomization = ControlsCustomization(),
     settingsControlsCustomization: SettingsControlsCustomization = SettingsControlsCustomization(),
@@ -74,6 +75,7 @@ fun EnhancedVideoPlayer(
         enableImmersiveMode = enableImmersiveMode,
         playImmediately = playImmediately,
         soundOff = soundOff,
+        disableControls = disableControls,
         currentTimeTickInMs = currentTimeTickInMs,
         controlsCustomization = controlsCustomization,
         settingsControlsCustomization = settingsControlsCustomization,
@@ -90,6 +92,7 @@ fun EnhancedVideoPlayer(
     enableImmersiveMode: Boolean = true,
     playImmediately: Boolean = true,
     soundOff: Boolean = true,
+    disableControls: Boolean = false,
     currentTimeTickInMs: Long = CURRENT_TIME_TICK_IN_MS,
     controlsCustomization: ControlsCustomization = ControlsCustomization(),
     transformSeekIncrementRatio: (tapCount: Int) -> Long = { it -> it * DEFAULT_SEEK_TIME_MS },
@@ -178,47 +181,51 @@ fun EnhancedVideoPlayer(
                 }
             }
         )
-        Box(modifier = Modifier.matchParentSize()) {
-            SeekHandler(
-                disableSeekForward = hasEnded,
-                isControlsVisible = isControlsVisible,
-                exoPlayer = exoPlayer,
-                controlsCustomization = controlsCustomization,
-                toggleControlsVisibility = { isControlsVisible = !isControlsVisible },
-                setControlsVisibility = ::setControlsVisibility,
-                transformSeekIncrementRatio = transformSeekIncrementRatio
+        if (!disableControls) {
+            Box(modifier = Modifier.matchParentSize()) {
+                SeekHandler(
+                    disableSeekForward = hasEnded,
+                    isControlsVisible = isControlsVisible,
+                    exoPlayer = exoPlayer,
+                    controlsCustomization = controlsCustomization,
+                    toggleControlsVisibility = {
+                        setControlsVisibility(!isControlsVisible)
+                    },
+                    setControlsVisibility = ::setControlsVisibility,
+                    transformSeekIncrementRatio = transformSeekIncrementRatio
+                )
+            }
+
+            PlayerControls(
+                title = title,
+                isVisible = isControlsVisible,
+                isPlaying = isPlaying,
+                isFullScreen = isFullScreen,
+                hasEnded = hasEnded,
+                speed = speed,
+                totalDuration = totalDuration,
+                currentTime = currentTime,
+                onPreviousClick = exoPlayer::seekToPrevious,
+                onNextClick = exoPlayer::seekToNext,
+                onPauseToggle = when {
+                    hasEnded -> exoPlayer::seekToDefaultPosition
+                    isPlaying -> exoPlayer::pause
+                    else -> exoPlayer::play
+                },
+                onFullScreenToggle = {
+                    when (isFullScreen) {
+                        true -> context.setPortrait()
+                        false -> context.setLandscape()
+                    }
+                },
+                onSpeedSelected = exoPlayer::setPlaybackSpeed,
+                onSeekBarValueChange = exoPlayer::seekTo,
+                customization = controlsCustomization,
+                settingsControlsCustomization = settingsControlsCustomization,
+                modifier = Modifier
+                    .matchParentSize()
+                    .testTag("PlayerControlsParent")
             )
         }
-
-        PlayerControls(
-            title = title,
-            isVisible = isControlsVisible,
-            isPlaying = isPlaying,
-            isFullScreen = isFullScreen,
-            hasEnded = hasEnded,
-            speed = speed,
-            totalDuration = totalDuration,
-            currentTime = currentTime,
-            onPreviousClick = exoPlayer::seekToPrevious,
-            onNextClick = exoPlayer::seekToNext,
-            onPauseToggle = when {
-                hasEnded -> exoPlayer::seekToDefaultPosition
-                isPlaying -> exoPlayer::pause
-                else -> exoPlayer::play
-            },
-            onFullScreenToggle = {
-                when (isFullScreen) {
-                    true -> context.setPortrait()
-                    false -> context.setLandscape()
-                }
-            },
-            onSpeedSelected = exoPlayer::setPlaybackSpeed,
-            onSeekBarValueChange = exoPlayer::seekTo,
-            customization = controlsCustomization,
-            settingsControlsCustomization = settingsControlsCustomization,
-            modifier = Modifier
-                .matchParentSize()
-                .testTag("PlayerControlsParent")
-        )
     }
 }

--- a/app/src/main/java/com/example/androidenhancedvideoplayer/MainActivity.kt
+++ b/app/src/main/java/com/example/androidenhancedvideoplayer/MainActivity.kt
@@ -66,6 +66,7 @@ fun VideoFromResources() {
         resourceId = R.raw.spinning_earth,
         zoomToFit = false,
         enableImmersiveMode = true,
+        disableControls = false,
         alwaysRepeat = false,
         settingsControlsCustomization = SettingsControlsCustomization(
             speeds = listOf(0.5f, 1f, 2f, 4f)


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

Add flags for both hiding the player controls and disable gestures (e.g. double tap to forward).

## Related Issues

- Closes #47 

## Progress

- [x] The Player should be created with hidden controls
- [x] The Player should not be able to interact with gestures

<!-- Also, don't forget to review your code before marking it as ready to merge -->

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [x] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [ ] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Toggle `disableControls` and check if the behavior is the expected

<!-- Describe how the reviewers can test your feature. -->

## Visual reference

<video src="https://github.com/profusion/android-enhanced-video-player/assets/9094028/2b59a239-3225-49df-bb6b-1fc4153a4d19"/>




