### PR TITLE
Feat/hls support

### DIFF
--- a/androidenhancedvideoplayer/build.gradle
+++ b/androidenhancedvideoplayer/build.gradle
@@ -69,7 +69,6 @@ dependencies {
     // exoplayer
     implementation "androidx.media3:media3-exoplayer:$mediaVersion"
     implementation "androidx.media3:media3-ui:$mediaVersion"
-    implementation "androidx.media3:media3-exoplayer-dash:$mediaVersion"
 }
 
 afterEvaluate {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     implementation "androidx.media3:media3-exoplayer:$mediaVersion"
     implementation "androidx.media3:media3-ui:$mediaVersion"
     implementation "androidx.media3:media3-exoplayer-dash:$mediaVersion"
+    implementation "androidx.media3:media3-exoplayer-hls:$mediaVersion"
 
     // our library
     implementation project(':androidenhancedvideoplayer')

--- a/app/src/main/java/com/example/androidenhancedvideoplayer/MainActivity.kt
+++ b/app/src/main/java/com/example/androidenhancedvideoplayer/MainActivity.kt
@@ -35,7 +35,7 @@ class MainActivity : ComponentActivity() {
                             .fillMaxSizeOnLandscape(orientation = orientation)
                             .fillMaxWidth()
                     ) {
-                        VideoFromResources()
+                        VideoFromHLSUri()
                     }
                     RecommendedVideosComponent()
                 }
@@ -50,6 +50,21 @@ fun VideoFromURL() {
         mediaItem = MediaItem.fromUri(
             "https://commondatastorage.googleapis.com/" +
                 "gtv-videos-bucket/sample/ElephantsDream.mp4"
+        ),
+        zoomToFit = false,
+        enableImmersiveMode = true,
+        alwaysRepeat = false,
+        settingsControlsCustomization = SettingsControlsCustomization(
+            speeds = listOf(0.5f, 1f, 2f, 4f)
+        )
+    )
+}
+
+@Composable
+fun VideoFromHLSUri() {
+    EnhancedVideoPlayer(
+        mediaItem = MediaItem.fromUri(
+            "https://demo-streaming.gcdn.co/videos/676_YJHUNNocCsrjiCDx/master.m3u8"
         ),
         zoomToFit = false,
         enableImmersiveMode = true,


### PR DESCRIPTION
## Description

Add support for HLS URI in `MediItem` as described by https://developer.android.com/guide/topics/media/exoplayer/hls


## Related Issues

Closes #57

## How to test it

1. Launch the main activity by passing the `VideoFromHLSUri` composable
2. Observe the HLS video being played

## Visual reference

[hls-example.webm](https://github.com/profusion/android-enhanced-video-player/assets/11635469/e9b8fdcd-7383-41b9-a136-a8d967e888d1)
