### PR TITLE
Feat loop control

### DIFF
--- a/androidenhancedvideoplayer/src/androidTest/java/com/profusion/androidenhancedvideoplayer/test/utils/DefaultPlayerControls.kt
+++ b/androidenhancedvideoplayer/src/androidTest/java/com/profusion/androidenhancedvideoplayer/test/utils/DefaultPlayerControls.kt
@@ -11,6 +11,7 @@ fun DefaultPlayerControls(
     isFullScreen: Boolean = false,
     hasEnded: Boolean = false,
     speed: Float = 1f,
+    isLoopEnabled: Boolean = false,
     videoTimer: Long = 0,
     totalDuration: Long = 0,
     onPreviousClick: () -> Unit = {},
@@ -18,6 +19,7 @@ fun DefaultPlayerControls(
     onNextClick: () -> Unit = {},
     onFullScreenToggle: () -> Unit = {},
     onSpeedSelected: (Float) -> Unit = {},
+    onIsLoopEnabledSelected: (Boolean) -> Unit = {},
     onSeekBarValueChange: (Long) -> Unit = {},
     customization: ControlsCustomization = ControlsCustomization(),
     settingsControlsCustomization: SettingsControlsCustomization = SettingsControlsCustomization()
@@ -29,6 +31,7 @@ fun DefaultPlayerControls(
         isFullScreen = isFullScreen,
         hasEnded = hasEnded,
         speed = speed,
+        isLoopEnabled = isLoopEnabled,
         currentTime = videoTimer,
         totalDuration = totalDuration,
         onPreviousClick = onPreviousClick,
@@ -36,6 +39,7 @@ fun DefaultPlayerControls(
         onNextClick = onNextClick,
         onFullScreenToggle = onFullScreenToggle,
         onSpeedSelected = onSpeedSelected,
+        onIsLoopEnabledSelected = onIsLoopEnabledSelected,
         onSeekBarValueChange = onSeekBarValueChange,
         customization = customization,
         settingsControlsCustomization = settingsControlsCustomization

--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/EnhancedVideoPlayer.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/EnhancedVideoPlayer.kt
@@ -5,22 +5,13 @@ import android.net.Uri
 import androidx.compose.animation.*
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.*
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.layout.Box
 import androidx.compose.material.*
 import androidx.compose.runtime.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.*
 import androidx.compose.ui.graphics.*
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -116,6 +107,7 @@ fun EnhancedVideoPlayer(
     var hasEnded by remember { mutableStateOf(exoPlayer.playbackState == ExoPlayer.STATE_ENDED) }
     var isControlsVisible by remember { mutableStateOf(false) }
     var speed by remember { mutableStateOf(exoPlayer.playbackParameters.speed) }
+    var loop by remember { mutableStateOf(exoPlayer.repeatMode == ExoPlayer.REPEAT_MODE_ALL) }
     var currentTime by remember { mutableStateOf(exoPlayer.contentPosition) }
     var totalDuration by remember { mutableStateOf(exoPlayer.duration) }
     var title by remember {
@@ -142,6 +134,7 @@ fun EnhancedVideoPlayer(
                 title = player.mediaMetadata.title?.toString()
                 currentTime = player.contentPosition
                 totalDuration = player.duration
+                loop = player.repeatMode == ExoPlayer.REPEAT_MODE_ALL
                 super.onEvents(player, events)
             }
         }
@@ -203,6 +196,7 @@ fun EnhancedVideoPlayer(
                 isFullScreen = isFullScreen,
                 hasEnded = hasEnded,
                 speed = speed,
+                isLoopEnabled = loop,
                 totalDuration = totalDuration,
                 currentTime = currentTime,
                 onPreviousClick = exoPlayer::seekToPrevious,
@@ -219,6 +213,13 @@ fun EnhancedVideoPlayer(
                     }
                 },
                 onSpeedSelected = exoPlayer::setPlaybackSpeed,
+                onIsLoopEnabledSelected = { value ->
+                    exoPlayer.repeatMode = if (value) {
+                        ExoPlayer.REPEAT_MODE_ALL
+                    } else {
+                        ExoPlayer.REPEAT_MODE_OFF
+                    }
+                },
                 onSeekBarValueChange = exoPlayer::seekTo,
                 customization = controlsCustomization,
                 settingsControlsCustomization = settingsControlsCustomization,

--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/BottomControls.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/BottomControls.kt
@@ -30,9 +30,11 @@ import com.profusion.androidenhancedvideoplayer.utils.formatElapsedTime
 fun BottomControls(
     isFullScreen: Boolean,
     speed: Float,
+    isLoopEnabled: Boolean,
     currentTime: Long,
     totalDuration: Long,
     onSpeedSelected: (Float) -> Unit,
+    onIsLoopEnabledSelected: (Boolean) -> Unit,
     onFullScreenToggle: () -> Unit,
     onSeekBarValueChange: (Long) -> Unit,
     customization: ControlsCustomization,
@@ -83,7 +85,9 @@ fun BottomControls(
                 Settings(
                     onDismissRequest = { isSettingsOpen = false },
                     speed = speed,
+                    isLoopEnabled = isLoopEnabled,
                     onSpeedSelected = onSpeedSelected,
+                    onIsLoopEnabledSelected = onIsLoopEnabledSelected,
                     customization = settingsControlsCustomization
                 )
             }

--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/PlayerControls.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/PlayerControls.kt
@@ -27,6 +27,7 @@ fun PlayerControls(
     isFullScreen: Boolean,
     hasEnded: Boolean,
     speed: Float,
+    isLoopEnabled: Boolean,
     currentTime: Long,
     totalDuration: Long,
     onPreviousClick: () -> Unit,
@@ -34,6 +35,7 @@ fun PlayerControls(
     onNextClick: () -> Unit,
     onFullScreenToggle: () -> Unit,
     onSpeedSelected: (Float) -> Unit,
+    onIsLoopEnabledSelected: (Boolean) -> Unit,
     onSeekBarValueChange: (Long) -> Unit,
     customization: ControlsCustomization,
     settingsControlsCustomization: SettingsControlsCustomization
@@ -50,10 +52,12 @@ fun PlayerControls(
             BottomControls(
                 isFullScreen = isFullScreen,
                 speed = speed,
+                isLoopEnabled = isLoopEnabled,
                 currentTime = currentTime,
                 totalDuration = totalDuration,
                 onFullScreenToggle = onFullScreenToggle,
                 onSpeedSelected = onSpeedSelected,
+                onIsLoopEnabledSelected = onIsLoopEnabledSelected,
                 onSeekBarValueChange = onSeekBarValueChange,
                 customization = customization,
                 settingsControlsCustomization = settingsControlsCustomization
@@ -82,6 +86,7 @@ private fun PreviewPlayerControls() {
         hasEnded = false,
         isFullScreen = false,
         speed = 1f,
+        isLoopEnabled = false,
         currentTime = 0L,
         totalDuration = 0L,
         onPreviousClick = {},
@@ -89,6 +94,7 @@ private fun PreviewPlayerControls() {
         onNextClick = {},
         onFullScreenToggle = {},
         onSpeedSelected = {},
+        onIsLoopEnabledSelected = {},
         onSeekBarValueChange = {},
         customization = ControlsCustomization(),
         settingsControlsCustomization = SettingsControlsCustomization()

--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/PlayerIcons.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/PlayerIcons.kt
@@ -127,3 +127,13 @@ fun RewindIcon(modifier: Modifier = Modifier) {
         modifier = modifier.testTag("RewindIcon")
     )
 }
+
+@Composable
+fun RepeatIcon(modifier: Modifier = Modifier) {
+    Icon(
+        painter = painterResource(id = R.drawable.ic_repeat),
+        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+        contentDescription = stringResource(R.string.settings_repeat_description),
+        modifier = modifier.testTag("RepeatIcon")
+    )
+}

--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/Settings.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/Settings.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -25,6 +26,7 @@ import kotlinx.coroutines.launch
 data class SettingsControlsCustomization(
     val speeds: List<Float> = listOf(0.5f, 0.75f, 1.0f, 1.25f, 1.5f),
     val speedIconContent: @Composable () -> Unit = { SpeedIcon() },
+    val repeatIconContent: @Composable () -> Unit = { RepeatIcon() },
     val modifier: Modifier = Modifier
 )
 
@@ -32,8 +34,10 @@ data class SettingsControlsCustomization(
 @Composable
 fun Settings(
     speed: Float,
+    isLoopEnabled: Boolean,
     onDismissRequest: () -> Unit,
     onSpeedSelected: (Float) -> Unit,
+    onIsLoopEnabledSelected: (Boolean) -> Unit,
     customization: SettingsControlsCustomization
 ) {
     val sheetState = rememberModalBottomSheetState()
@@ -49,6 +53,12 @@ fun Settings(
             value = speed,
             items = customization.speeds,
             onSelected = onSpeedSelected
+        )
+        SettingsSelector(
+            label = stringResource(id = R.string.settings_repeat),
+            icon = customization.repeatIconContent,
+            value = isLoopEnabled,
+            onSelected = onIsLoopEnabledSelected
         )
     }
 }
@@ -107,14 +117,44 @@ private fun <T>SettingsSelector(
     }
 }
 
+@Composable
+private fun SettingsSelector(
+    label: String,
+    value: Boolean,
+    onSelected: (Boolean) -> Unit,
+    icon: @Composable () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    val currentOnSelected by rememberUpdatedState(onSelected)
+
+    ListItem(
+        headlineContent = { Text(label) },
+        leadingContent = icon,
+        trailingContent = {
+            Text(
+                text = if (value) {
+                    stringResource(id = R.string.settings_on)
+                } else {
+                    stringResource(id = R.string.settings_off)
+                }
+            )
+        },
+        modifier = modifier
+            .clickable(onClick = { currentOnSelected(!value) })
+            .testTag("${label}SettingsButton")
+    )
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Preview(showBackground = true)
 @Composable
 private fun PreviewSettings() {
     Settings(
         speed = 1.0f,
+        isLoopEnabled = false,
         onDismissRequest = { },
         onSpeedSelected = { },
+        onIsLoopEnabledSelected = { },
         customization = SettingsControlsCustomization()
     )
 }

--- a/androidenhancedvideoplayer/src/main/res/drawable/ic_repeat.xml
+++ b/androidenhancedvideoplayer/src/main/res/drawable/ic_repeat.xml
@@ -1,0 +1,5 @@
+<vector android:height="32dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="32dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M7,7h10v3l4,-4 -4,-4v3L5,5v6h2L7,7zM17,17L7,17v-3l-4,4 4,4v-3h12v-6h-2v4z"/>
+</vector>

--- a/androidenhancedvideoplayer/src/main/res/values-pt-rBR/settings_strings.xml
+++ b/androidenhancedvideoplayer/src/main/res/values-pt-rBR/settings_strings.xml
@@ -1,5 +1,8 @@
 <resources>
     <string name="settings_check_description">Selecionado</string>
+    <string name="settings_off">Desativado</string>
+    <string name="settings_on">Ativado</string>
+    <string name="settings_repeat">Repetir vídeo</string>
     <string name="settings_repeat_description">Repetir</string>
     <string name="settings_speed">Velocidade</string>
     <string name="settings_speed_description">Velocidade</string>

--- a/androidenhancedvideoplayer/src/main/res/values-pt-rBR/settings_strings.xml
+++ b/androidenhancedvideoplayer/src/main/res/values-pt-rBR/settings_strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="settings_check_description">Selecionado</string>
+    <string name="settings_repeat_description">Repetir</string>
     <string name="settings_speed">Velocidade</string>
     <string name="settings_speed_description">Velocidade</string>
 </resources>

--- a/androidenhancedvideoplayer/src/main/res/values/settings_strings.xml
+++ b/androidenhancedvideoplayer/src/main/res/values/settings_strings.xml
@@ -1,5 +1,8 @@
 <resources>
     <string name="settings_check_description">Selected</string>
+    <string name="settings_off">Off</string>
+    <string name="settings_on">On</string>
+    <string name="settings_repeat">Loop video</string>
     <string name="settings_repeat_description">Loop</string>
     <string name="settings_speed">Playback Speed</string>
     <string name="settings_speed_description">Speed</string>

--- a/androidenhancedvideoplayer/src/main/res/values/settings_strings.xml
+++ b/androidenhancedvideoplayer/src/main/res/values/settings_strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="settings_check_description">Selected</string>
+    <string name="settings_repeat_description">Loop</string>
     <string name="settings_speed">Playback Speed</string>
     <string name="settings_speed_description">Speed</string>
 </resources>

--- a/app/src/main/java/com/example/androidenhancedvideoplayer/MainActivity.kt
+++ b/app/src/main/java/com/example/androidenhancedvideoplayer/MainActivity.kt
@@ -68,7 +68,7 @@ fun VideoFromHLSUri() {
         ),
         zoomToFit = false,
         enableImmersiveMode = true,
-        alwaysRepeat = false,
+        alwaysRepeat = true,
         settingsControlsCustomization = SettingsControlsCustomization(
             speeds = listOf(0.5f, 1f, 2f, 4f)
         )


### PR DESCRIPTION
## Description

- Allow the user to control if the video should loop or not by adding a loop control to the settings menu

## Related Issues

- Closes #55 

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

- Open the settings menu and click on the loop item

## Visual reference

https://github.com/profusion/android-enhanced-video-player/assets/35314270/039a25fc-4fd8-4cf4-973d-06cb23a09698

