### PR TITLE
Hide the controls after a timeout

### DIFF
--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/EnhancedVideoPlayer.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/EnhancedVideoPlayer.kt
@@ -33,10 +33,11 @@ import com.profusion.androidenhancedvideoplayer.utils.setLandscape
 import com.profusion.androidenhancedvideoplayer.utils.setNavigationBarVisibility
 import com.profusion.androidenhancedvideoplayer.utils.setPortrait
 import com.profusion.androidenhancedvideoplayer.utils.setStatusBarVisibility
+import kotlinx.coroutines.delay
 
 private const val MAIN_PACKAGE_PATH_PREFIX = "android.resource://"
 private const val CURRENT_TIME_TICK_IN_MS = 50L
-
+private const val PLAYER_CONTROLS_VISIBILITY_DURATION_IN_MS = 3000L // 3 seconds
 private const val DEFAULT_SEEK_TIME_MS = 10 * 1000L // 10 seconds
 
 @androidx.annotation.OptIn(UnstableApi::class)
@@ -85,6 +86,7 @@ fun EnhancedVideoPlayer(
     soundOff: Boolean = true,
     disableControls: Boolean = false,
     currentTimeTickInMs: Long = CURRENT_TIME_TICK_IN_MS,
+    controlsVisibilityDurationInMs: Long = PLAYER_CONTROLS_VISIBILITY_DURATION_IN_MS,
     controlsCustomization: ControlsCustomization = ControlsCustomization(),
     transformSeekIncrementRatio: (tapCount: Int) -> Long = { it -> it * DEFAULT_SEEK_TIME_MS },
     settingsControlsCustomization: SettingsControlsCustomization = SettingsControlsCustomization()
@@ -150,6 +152,13 @@ fun EnhancedVideoPlayer(
         enabled = isPlaying && isControlsVisible
     ) {
         currentTime = exoPlayer.currentPosition
+    }
+
+    LaunchedEffect(isControlsVisible) {
+        if (isControlsVisible && controlsVisibilityDurationInMs > 0) {
+            delay(controlsVisibilityDurationInMs)
+            isControlsVisible = false
+        }
     }
 
     Box(


### PR DESCRIPTION
## Description

- Hide the controls after a specific timeout 
  - The time is customizable 
 
## Related Issues

- Closes #44 

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

- Click on the screen to open the controls and wait 

## Visual reference

https://github.com/profusion/android-enhanced-video-player/assets/35314270/4714d68e-57a1-4845-aa28-d1699c4940ed

