### PR TITLE
Picture in Picture

### DIFF
--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/EnhancedVideoPlayer.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/EnhancedVideoPlayer.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.*
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
@@ -45,12 +44,9 @@ private const val DEFAULT_SEEK_TIME_MS = 10 * 1000L // 10 seconds
 @androidx.annotation.OptIn(UnstableApi::class)
 @Composable
 fun EnhancedVideoPlayer(
-    mediaItem: MediaItem,
-    alwaysRepeat: Boolean = true,
+    exoPlayer: ExoPlayer,
     zoomToFit: Boolean = true,
     enableImmersiveMode: Boolean = true,
-    playImmediately: Boolean = true,
-    soundOff: Boolean = true,
     disableControls: Boolean = false,
     currentTimeTickInMs: Long = CURRENT_TIME_TICK_IN_MS,
     controlsVisibilityDurationInMs: Long = PLAYER_CONTROLS_VISIBILITY_DURATION_IN_MS,
@@ -59,19 +55,8 @@ fun EnhancedVideoPlayer(
     settingsControlsCustomization: SettingsControlsCustomization = SettingsControlsCustomization()
 ) {
     val context = LocalContext.current
-
     val orientation = LocalConfiguration.current.orientation
 
-    val exoPlayer = remember {
-        ExoPlayer.Builder(context)
-            .build().apply {
-                setMediaItem(mediaItem)
-                volume = if (soundOff) 0f else 1f
-                repeatMode = if (alwaysRepeat) Player.REPEAT_MODE_ALL else Player.REPEAT_MODE_OFF
-                playWhenReady = playImmediately
-                prepare()
-            }
-    }
     var isPlaying by remember { mutableStateOf(exoPlayer.isPlaying) }
     var hasEnded by remember { mutableStateOf(exoPlayer.playbackState == ExoPlayer.STATE_ENDED) }
     var isControlsVisible by remember { mutableStateOf(false) }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,9 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:configChanges="orientation"
+            android:supportsPictureInPicture="true"
+            android:configChanges=
+                "screenSize|smallestScreenSize|screenLayout|orientation"
             android:theme="@style/Theme.AndroidEnhancedVideoPlayer">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/androidenhancedvideoplayer/MainActivity.kt
+++ b/app/src/main/java/com/example/androidenhancedvideoplayer/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.core.view.WindowCompat
@@ -18,9 +19,11 @@ import com.example.androidenhancedvideoplayer.utils.ExampleUrl
 import com.example.androidenhancedvideoplayer.utils.fillMaxSizeOnLandscape
 import com.profusion.androidenhancedvideoplayer.components.EnhancedVideoPlayer
 import com.profusion.androidenhancedvideoplayer.components.playerOverlay.SettingsControlsCustomization
+import kotlinx.coroutines.flow.MutableStateFlow
 
 class MainActivity : ComponentActivity() {
     private lateinit var exoPlayer: ExoPlayer
+    private val isInPictureInPictureMode: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     private fun initializeExoPlayer() {
         exoPlayer = ExoPlayer
@@ -47,6 +50,8 @@ class MainActivity : ComponentActivity() {
             AndroidEnhancedVideoPlayerTheme {
                 val orientation = LocalConfiguration.current.orientation
 
+                val isInPictureInPictureModeState = isInPictureInPictureMode.collectAsState()
+
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -61,6 +66,7 @@ class MainActivity : ComponentActivity() {
                             exoPlayer = exoPlayer,
                             zoomToFit = false,
                             enableImmersiveMode = true,
+                            disableControls = isInPictureInPictureModeState.value,
                             settingsControlsCustomization = SettingsControlsCustomization(
                                 speeds = listOf(0.5f, 1f, 2f, 4f)
                             )
@@ -70,5 +76,25 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    override fun onUserLeaveHint() {
+        super.onUserLeaveHint()
+
+        if (exoPlayer.isPlaying) {
+            enterPictureInPictureMode(
+                android.app.PictureInPictureParams.Builder()
+                    .setAspectRatio(android.util.Rational(16, 9))
+                    .build()
+            )
+        }
+    }
+
+    override fun onPictureInPictureModeChanged(
+        value: Boolean,
+        newConfig: android.content.res.Configuration
+    ) {
+        super.onPictureInPictureModeChanged(value, newConfig)
+        isInPictureInPictureMode.value = value
     }
 }

--- a/app/src/main/java/com/example/androidenhancedvideoplayer/MainActivity.kt
+++ b/app/src/main/java/com/example/androidenhancedvideoplayer/MainActivity.kt
@@ -7,12 +7,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.safeDrawingPadding
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalContext
 import androidx.core.view.WindowCompat
 import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.ExoPlayer
 import com.example.androidenhancedvideoplayer.components.RecommendedVideosComponent
 import com.example.androidenhancedvideoplayer.ui.theme.AndroidEnhancedVideoPlayerTheme
 import com.example.androidenhancedvideoplayer.utils.ExampleUrl
@@ -21,12 +20,33 @@ import com.profusion.androidenhancedvideoplayer.components.EnhancedVideoPlayer
 import com.profusion.androidenhancedvideoplayer.components.playerOverlay.SettingsControlsCustomization
 
 class MainActivity : ComponentActivity() {
+    private lateinit var exoPlayer: ExoPlayer
+
+    private fun initializeExoPlayer() {
+        exoPlayer = ExoPlayer
+            .Builder(applicationContext)
+            .build()
+            .apply {
+                setMediaItem(MediaItem.fromUri(ExampleUrl.RESOURCE))
+                playWhenReady = true
+                prepare()
+            }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        exoPlayer.release()
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         super.onCreate(savedInstanceState)
+        initializeExoPlayer()
+
         setContent {
             AndroidEnhancedVideoPlayerTheme {
                 val orientation = LocalConfiguration.current.orientation
+
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -37,81 +57,18 @@ class MainActivity : ComponentActivity() {
                             .fillMaxSizeOnLandscape(orientation = orientation)
                             .fillMaxWidth()
                     ) {
-                        VideoFromMSSUri()
+                        EnhancedVideoPlayer(
+                            exoPlayer = exoPlayer,
+                            zoomToFit = false,
+                            enableImmersiveMode = true,
+                            settingsControlsCustomization = SettingsControlsCustomization(
+                                speeds = listOf(0.5f, 1f, 2f, 4f)
+                            )
+                        )
                     }
                     RecommendedVideosComponent()
                 }
             }
         }
     }
-}
-
-@Composable
-fun VideoFromURL() {
-    EnhancedVideoPlayer(
-        mediaItem = MediaItem.fromUri(ExampleUrl.MP4),
-        zoomToFit = false,
-        enableImmersiveMode = true,
-        alwaysRepeat = false,
-        settingsControlsCustomization = SettingsControlsCustomization(
-            speeds = listOf(0.5f, 1f, 2f, 4f)
-        )
-    )
-}
-
-@Composable
-fun VideoFromHLSUri() {
-    EnhancedVideoPlayer(
-        mediaItem = MediaItem.fromUri(ExampleUrl.HLS),
-        zoomToFit = false,
-        enableImmersiveMode = true,
-        alwaysRepeat = true,
-        settingsControlsCustomization = SettingsControlsCustomization(
-            speeds = listOf(0.5f, 1f, 2f, 4f)
-        )
-    )
-}
-
-@Composable
-fun VideoFromDASHUri() {
-    EnhancedVideoPlayer(
-        mediaItem = MediaItem.fromUri(ExampleUrl.DASH),
-        zoomToFit = false,
-        enableImmersiveMode = true,
-        alwaysRepeat = false,
-        settingsControlsCustomization = SettingsControlsCustomization(
-            speeds = listOf(0.5f, 1f, 2f, 4f)
-        )
-    )
-}
-
-@Composable
-fun VideoFromMSSUri() {
-    EnhancedVideoPlayer(
-        mediaItem = MediaItem.fromUri(ExampleUrl.MSS),
-        zoomToFit = false,
-        enableImmersiveMode = true,
-        alwaysRepeat = false,
-        settingsControlsCustomization = SettingsControlsCustomization(
-            speeds = listOf(0.5f, 1f, 2f, 4f)
-        )
-    )
-}
-
-@Composable
-fun VideoFromResources() {
-    val context = LocalContext.current
-
-    EnhancedVideoPlayer(
-        mediaItem = MediaItem.fromUri(
-            "android.resource://${context.packageName}/raw/spinning_earth"
-        ),
-        zoomToFit = false,
-        enableImmersiveMode = true,
-        disableControls = false,
-        alwaysRepeat = false,
-        settingsControlsCustomization = SettingsControlsCustomization(
-            speeds = listOf(0.5f, 1f, 2f, 4f)
-        )
-    )
 }

--- a/app/src/main/java/com/example/androidenhancedvideoplayer/utils/ExampleUrl.kt
+++ b/app/src/main/java/com/example/androidenhancedvideoplayer/utils/ExampleUrl.kt
@@ -7,4 +7,5 @@ object ExampleUrl {
     const val HLS = "https://demo-streaming.gcdn.co/videos/676_YJHUNNocCsrjiCDx/master.m3u8"
     const val MP4 = "https://commondatastorage.googleapis.com/" +
         "gtv-videos-bucket/sample/ElephantsDream.mp4"
+    const val RESOURCE = "android.resource://com.example.teste/raw/spinning_earth"
 }


### PR DESCRIPTION
## Description

- Pass an ExoPlayer instance from outside the EnhancedVideoPlayer, which can be useful for adding custom callbacks or calling methods that are not exposed
- Add Picture in Picture support in the AndroidManifest.xml
- Enter Picture in Picture mode when the user leaves hint

Reference:

- https://developer.android.com/develop/ui/views/picture-in-picture

## Related Issues

- Closes #51 

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

- Open the app and move to the background while the video is playing

## Visual reference

https://github.com/profusion/android-enhanced-video-player/assets/35314270/4c28f7cc-9afc-4f20-8f76-8e8c2228f51e