### PR TITLE
Media Quality Control

### DIFF
--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/PlayerIcons.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/PlayerIcons.kt
@@ -90,6 +90,15 @@ fun SettingsIcon() {
 }
 
 @Composable
+fun QualityIcon() {
+    Icon(
+        painter = painterResource(id = R.drawable.ic_quality),
+        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+        contentDescription = stringResource(R.string.controls_quality_description)
+    )
+}
+
+@Composable
 fun SpeedIcon() {
     Icon(
         painter = painterResource(id = R.drawable.ic_speed),

--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/utils/TrackQualityItem.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/utils/TrackQualityItem.kt
@@ -1,0 +1,38 @@
+package com.profusion.androidenhancedvideoplayer.utils
+
+import androidx.compose.runtime.Stable
+import androidx.media3.common.TrackGroup
+import androidx.media3.common.util.UnstableApi
+
+sealed interface TrackQualityItem
+
+@UnstableApi
+@Stable
+data class TrackQualityAuto(
+    private val label: String
+) : TrackQualityItem {
+    override fun toString(): String {
+        return label
+    }
+}
+
+@UnstableApi
+@Stable
+data class TrackQualityItemValue(
+    val trackIndex: Int,
+    val group: TrackGroup
+) : Comparable<TrackQualityItemValue>, TrackQualityItem {
+
+    private val format get() = group.getFormat(trackIndex)
+
+    override fun compareTo(other: TrackQualityItemValue) = compareValuesBy(
+        this,
+        other,
+        { it.format.height },
+        { it.format.bitrate }
+    )
+
+    override fun toString(): String {
+        return format.buildQualityLabel()
+    }
+}

--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/utils/TrackQualityItem.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/utils/TrackQualityItem.kt
@@ -1,8 +1,12 @@
 package com.profusion.androidenhancedvideoplayer.utils
 
+import android.os.Bundle
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.mapSaver
 import androidx.media3.common.TrackGroup
 import androidx.media3.common.util.UnstableApi
+import com.google.common.collect.ImmutableList
 
 sealed interface TrackQualityItem
 
@@ -35,4 +39,75 @@ data class TrackQualityItemValue(
     override fun toString(): String {
         return format.buildQualityLabel()
     }
+}
+
+object TrackQualityItemKey {
+    const val LABEL = "label"
+    const val GROUP = "group"
+    const val TRACK_INDEX = "track"
+    const val TYPE = "type"
+    const val TYPE_AUTO = "auto"
+    const val TYPE_ITEM_VALUE = "value"
+}
+
+@UnstableApi
+fun saveTrackQualityItem(item: TrackQualityItem): Map<String, Any> {
+    return when (item) {
+        is TrackQualityItemValue -> {
+            mapOf(
+                TrackQualityItemKey.TYPE to TrackQualityItemKey.TYPE_ITEM_VALUE,
+                TrackQualityItemKey.GROUP to item.group.toBundle(),
+                TrackQualityItemKey.TRACK_INDEX to item.trackIndex
+            )
+        }
+        is TrackQualityAuto -> {
+            mapOf(
+                TrackQualityItemKey.TYPE to TrackQualityItemKey.TYPE_AUTO,
+                TrackQualityItemKey.LABEL to item.toString()
+            )
+        }
+    }
+}
+
+@UnstableApi
+fun restoreTrackQualityItem(map: Map<String, Any?>): TrackQualityItem {
+    return when (map[TrackQualityItemKey.TYPE] as String) {
+        TrackQualityItemKey.TYPE_ITEM_VALUE -> {
+            TrackQualityItemValue(
+                trackIndex = map[TrackQualityItemKey.TRACK_INDEX] as Int,
+                group = TrackGroup.CREATOR.fromBundle(map[TrackQualityItemKey.GROUP] as Bundle)
+            )
+        }
+        else -> {
+            TrackQualityAuto(map[TrackQualityItemKey.LABEL] as String)
+        }
+    }
+}
+
+@UnstableApi
+val TrackQualityItemSaver = run {
+    mapSaver(
+        save = {
+            saveTrackQualityItem(it)
+        },
+        restore = {
+            restoreTrackQualityItem(it)
+        }
+    )
+}
+
+@UnstableApi
+fun saveTrackQualityItemList(trackQualityItemList: List<TrackQualityItem>): List<Any> =
+    trackQualityItemList.map { saveTrackQualityItem(it) }
+
+@UnstableApi
+fun restoreTrackQualityItemList(list: List<Any>): List<TrackQualityItem> =
+    ImmutableList.copyOf(list.map { restoreTrackQualityItem(it as Map<String, Any>) })
+
+@UnstableApi
+val TrackQualityItemListSaver = run {
+    listSaver(
+        save = { list -> saveTrackQualityItemList(list) },
+        restore = { list -> restoreTrackQualityItemList(list) }
+    )
 }

--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/utils/TrackUtils.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/utils/TrackUtils.kt
@@ -1,0 +1,89 @@
+package com.profusion.androidenhancedvideoplayer.utils
+
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.Format
+import androidx.media3.common.TrackSelectionOverride
+import androidx.media3.common.TrackSelectionParameters
+import androidx.media3.common.Tracks
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+
+private const val NO_ROLE_FLAGS = 0
+
+@OptIn(UnstableApi::class)
+fun generateTrackQualityOptions(tracks: Tracks): List<TrackQualityItem> {
+    val qualityOptions = ArrayList<TrackQualityItemValue>()
+
+    for (group in tracks.groups) {
+        for (trackIndex in 0 until group.length) {
+            if (group.isTrackSupported(trackIndex) &&
+                group.mediaTrackGroup.type == C.TRACK_TYPE_VIDEO &&
+                group.getTrackFormat(trackIndex).isVideoTrackPlayable()
+            ) {
+                qualityOptions += TrackQualityItemValue(
+                    group = group.mediaTrackGroup,
+                    trackIndex = trackIndex
+                )
+            }
+        }
+    }
+
+    return qualityOptions.sortedDescending()
+}
+
+@UnstableApi
+fun TrackSelectionParameters.getChangedTrackSelection(
+    trackType: Int
+): TrackSelectionOverride? = overrides.values.firstOrNull { it.type == trackType }
+
+@UnstableApi
+fun TrackSelectionParameters.getSelectedTrackQualityItem(
+    autoLabel: String
+): TrackQualityItem {
+    val videoTrackOverride = getChangedTrackSelection(C.TRACK_TYPE_VIDEO)
+        ?: return TrackQualityAuto(autoLabel)
+
+    val index = videoTrackOverride.trackIndices.single()
+        ?: return TrackQualityAuto(autoLabel)
+
+    val group = videoTrackOverride.mediaTrackGroup
+
+    return TrackQualityItemValue(
+        group = group,
+        trackIndex = index
+    )
+}
+
+fun ExoPlayer.setVideoQuality(track: TrackQualityItem) {
+    trackSelectionParameters = when (track) {
+        is TrackQualityAuto -> {
+            trackSelectionParameters
+                .buildUpon()
+                .clearOverridesOfType(C.TRACK_TYPE_VIDEO)
+                .build()
+        }
+        is TrackQualityItemValue -> {
+            trackSelectionParameters
+                .buildUpon()
+                .clearOverridesOfType(C.TRACK_TYPE_VIDEO)
+                .addOverride(
+                    TrackSelectionOverride(
+                        track.group,
+                        track.trackIndex
+                    )
+                )
+                .build()
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+fun Format.buildQualityLabel(): String {
+    return "${height}p - ${bitrate / 1000}kbps"
+}
+
+@OptIn(UnstableApi::class)
+private fun Format.isVideoTrackPlayable(): Boolean {
+    return roleFlags == NO_ROLE_FLAGS
+}

--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/utils/TrackUtils.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/utils/TrackUtils.kt
@@ -8,11 +8,15 @@ import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.common.Tracks
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import com.google.common.collect.ImmutableList
 
 private const val NO_ROLE_FLAGS = 0
 
 @OptIn(UnstableApi::class)
-fun generateTrackQualityOptions(tracks: Tracks): List<TrackQualityItem> {
+fun generateTrackQualityOptions(
+    tracks: Tracks,
+    autoTrack: TrackQualityItem
+): ImmutableList<TrackQualityItem> {
     val qualityOptions = ArrayList<TrackQualityItemValue>()
 
     for (group in tracks.groups) {
@@ -29,7 +33,7 @@ fun generateTrackQualityOptions(tracks: Tracks): List<TrackQualityItem> {
         }
     }
 
-    return qualityOptions.sortedDescending()
+    return ImmutableList.copyOf(listOf(autoTrack) + qualityOptions.sortedDescending())
 }
 
 @UnstableApi
@@ -39,13 +43,13 @@ fun TrackSelectionParameters.getChangedTrackSelection(
 
 @UnstableApi
 fun TrackSelectionParameters.getSelectedTrackQualityItem(
-    autoLabel: String
+    autoTrack: TrackQualityItem
 ): TrackQualityItem {
     val videoTrackOverride = getChangedTrackSelection(C.TRACK_TYPE_VIDEO)
-        ?: return TrackQualityAuto(autoLabel)
+        ?: return autoTrack
 
     val index = videoTrackOverride.trackIndices.single()
-        ?: return TrackQualityAuto(autoLabel)
+        ?: return autoTrack
 
     val group = videoTrackOverride.mediaTrackGroup
 

--- a/androidenhancedvideoplayer/src/main/res/drawable/ic_quality.xml
+++ b/androidenhancedvideoplayer/src/main/res/drawable/ic_quality.xml
@@ -1,0 +1,5 @@
+<vector android:height="32dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="32dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M3,17v2h6v-2L3,17zM3,5v2h10L13,5L3,5zM13,21v-2h8v-2h-8v-2h-2v6h2zM7,9v2L3,11v2h4v2h2L9,9L7,9zM21,13v-2L11,11v2h10zM15,9h2L17,7h4L21,5h-4L17,3h-2v6z"/>
+</vector>

--- a/androidenhancedvideoplayer/src/main/res/values-pt-rBR/controls_strings.xml
+++ b/androidenhancedvideoplayer/src/main/res/values-pt-rBR/controls_strings.xml
@@ -9,6 +9,7 @@
     <string name="controls_pause_description">Pausar</string>
     <string name="controls_play_description">Reproduzir</string>
     <string name="controls_previous_description">Anterior</string>
+    <string name="controls_quality_description">Qualidade</string>
     <string name="controls_replay_description">Repetir</string>
     <string name="controls_rewind_description">Retroceder</string>
     <string name="controls_settings_description">Configurações</string>

--- a/androidenhancedvideoplayer/src/main/res/values-pt-rBR/settings_strings.xml
+++ b/androidenhancedvideoplayer/src/main/res/values-pt-rBR/settings_strings.xml
@@ -2,6 +2,9 @@
     <string name="settings_check_description">Selecionado</string>
     <string name="settings_off">Desativado</string>
     <string name="settings_on">Ativado</string>
+    <string name="settings_quality">Qualidade do vídeo</string>
+    <string name="settings_quality_auto">Auto</string>
+    <string name="settings_quality_description">Qualidade</string>
     <string name="settings_repeat">Repetir vídeo</string>
     <string name="settings_repeat_description">Repetir</string>
     <string name="settings_speed">Velocidade</string>

--- a/androidenhancedvideoplayer/src/main/res/values/controls_strings.xml
+++ b/androidenhancedvideoplayer/src/main/res/values/controls_strings.xml
@@ -9,6 +9,7 @@
     <string name="controls_pause_description">Pause</string>
     <string name="controls_play_description">Play</string>
     <string name="controls_previous_description">Previous</string>
+    <string name="controls_quality_description">Quality</string>
     <string name="controls_replay_description">Replay</string>
     <string name="controls_rewind_description">Rewind</string>
     <string name="controls_settings_description">Settings</string>

--- a/androidenhancedvideoplayer/src/main/res/values/settings_strings.xml
+++ b/androidenhancedvideoplayer/src/main/res/values/settings_strings.xml
@@ -2,6 +2,9 @@
     <string name="settings_check_description">Selected</string>
     <string name="settings_off">Off</string>
     <string name="settings_on">On</string>
+    <string name="settings_quality">Video Quality</string>
+    <string name="settings_quality_auto">Auto</string>
+    <string name="settings_quality_description">Quality</string>
     <string name="settings_repeat">Loop video</string>
     <string name="settings_repeat_description">Loop</string>
     <string name="settings_speed">Playback Speed</string>

--- a/app/src/main/java/com/example/androidenhancedvideoplayer/MainActivity.kt
+++ b/app/src/main/java/com/example/androidenhancedvideoplayer/MainActivity.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.core.view.WindowCompat
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.trackselection.AdaptiveTrackSelection
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.exoplayer.util.EventLogger
 import com.example.androidenhancedvideoplayer.components.RecommendedVideosComponent
 import com.example.androidenhancedvideoplayer.ui.theme.AndroidEnhancedVideoPlayerTheme
@@ -26,12 +28,16 @@ class MainActivity : ComponentActivity() {
     private lateinit var exoPlayer: ExoPlayer
     private val isInPictureInPictureMode: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
+    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
     private fun initializeExoPlayer() {
         exoPlayer = ExoPlayer
             .Builder(applicationContext)
+            .setTrackSelector(
+                DefaultTrackSelector(applicationContext, AdaptiveTrackSelection.Factory())
+            )
             .build()
             .apply {
-                setMediaItem(MediaItem.fromUri(ExampleUrl.HLS))
+                setMediaItem(MediaItem.fromUri(ExampleUrl.HLS_MULTI_AUDIO))
                 playWhenReady = true
                 addAnalyticsListener(EventLogger())
                 prepare()

--- a/app/src/main/java/com/example/androidenhancedvideoplayer/MainActivity.kt
+++ b/app/src/main/java/com/example/androidenhancedvideoplayer/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.core.view.WindowCompat
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.util.EventLogger
 import com.example.androidenhancedvideoplayer.components.RecommendedVideosComponent
 import com.example.androidenhancedvideoplayer.ui.theme.AndroidEnhancedVideoPlayerTheme
 import com.example.androidenhancedvideoplayer.utils.ExampleUrl
@@ -32,6 +33,7 @@ class MainActivity : ComponentActivity() {
             .apply {
                 setMediaItem(MediaItem.fromUri(ExampleUrl.HLS))
                 playWhenReady = true
+                addAnalyticsListener(EventLogger())
                 prepare()
             }
     }

--- a/app/src/main/java/com/example/androidenhancedvideoplayer/utils/ExampleUrl.kt
+++ b/app/src/main/java/com/example/androidenhancedvideoplayer/utils/ExampleUrl.kt
@@ -8,4 +8,8 @@ object ExampleUrl {
     const val MP4 = "https://commondatastorage.googleapis.com/" +
         "gtv-videos-bucket/sample/ElephantsDream.mp4"
     const val RESOURCE = "android.resource://com.example.teste/raw/spinning_earth"
+    const val HLS2 = "https://demo.unified-streaming.com/k8s/" +
+        "features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8"
+    const val HLS_MULTI_AUDIO = "https://d3rlna7iyyu8wu.cloudfront.net/skip_armstrong/" +
+        "skip_armstrong_multi_language_subs.m3u8"
 }


### PR DESCRIPTION
## Description

Add video quality selector when more than one available

## Related Issues

- Closes #50

## Progress

- [x] The settings menu should have the option to change the quality
- [x] Qualities available should be fetched from the manifest
- [x] Qualities list should have an `Auto` option if available
- [x] Should be default on `Auto`


<!-- Also, don't forget to review your code before marking it as ready to merge -->

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [ ] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

In settings menu, try to change between available qualities.

<!-- Describe how the reviewers can test your feature. -->

## Visual reference



https://github.com/profusion/android-enhanced-video-player/assets/9094028/242f3069-3c6e-46f3-826e-9c46e64850d0


