### PR TITLE
Add a CI to automatically release new versions + release v0.2.0

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,26 @@
+name: Auto Release
+
+on:
+  workflow_run:
+    workflows: [CI Android Enhanced Video Player]
+    types:
+      - completed
+    branches:
+      - main
+
+jobs:
+  auto-tag:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: profusion/action-autorelease@main
+        with:
+          properties_path: 'gradle.properties'
+          property_name: 'VERSION_NAME'
+          tag_prefix: 'v'
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 # Library version
-VERSION_NAME=0.1.0
+VERSION_NAME=0.2.0
 # Jitpack package
 GROUP=com.github.profusion
 # Artifact ID


### PR DESCRIPTION
## Description

- Create a GitHub Action to automatically create new GitHub releases when the `VERSION_NAME` in the `gradle.properties` file changes.
  - https://github.com/profusion/action-autorelease
- Integrate this action into our CI so it can create releases automatically

## Related Issues

- Closes #20

## How to test it

Testing has been done in the following repository:

- https://github.com/ricardodalarme/gradle-test/actions

If you'd like to test it yourself, create a workflow based on [this](https://github.com/ricardodalarme/gradle-test/blob/main/.github/workflows/main.yml) one and play with changing the version name in the gradle.properties file. 

