### PR TITLE
Fix: Settings Modal Padding

### DIFF
--- a/androidenhancedvideoplayer/build.gradle
+++ b/androidenhancedvideoplayer/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-graphics'
     implementation 'androidx.compose.ui:ui-tooling-preview'
-    implementation 'androidx.compose.material3:material3:1.1.0'
+    implementation 'androidx.compose.material3:material3:1.1.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/Settings.kt
+++ b/androidenhancedvideoplayer/src/main/java/com/profusion/androidenhancedvideoplayer/components/playerOverlay/Settings.kt
@@ -3,6 +3,8 @@ package com.profusion.androidenhancedvideoplayer.components.playerOverlay
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ModalBottomSheet
@@ -42,7 +44,7 @@ fun Settings(
     onIsLoopEnabledSelected: (Boolean) -> Unit,
     customization: SettingsControlsCustomization
 ) {
-    val sheetState = rememberModalBottomSheetState()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
@@ -76,7 +78,7 @@ private fun <T>SettingsSelector(
     modifier: Modifier = Modifier
 ) {
     var isSelectorOpen by rememberSaveable { mutableStateOf(false) }
-    val sheetState = rememberModalBottomSheetState()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scope = rememberCoroutineScope()
 
     ListItem(
@@ -94,26 +96,28 @@ private fun <T>SettingsSelector(
             sheetState = sheetState,
             modifier = Modifier.testTag("${label}SettingsSelector")
         ) {
-            items.forEach { item ->
-                ListItem(
-                    headlineContent = { Text(text = item.toString()) },
-                    leadingContent = {
-                        val iconSize = Dimensions.xlarge
-                        if (item == value) {
-                            CheckIcon(
-                                modifier = Modifier.size(iconSize)
-                            )
-                        } else {
-                            Box(Modifier.size(iconSize))
+            LazyColumn {
+                items(items) { item ->
+                    ListItem(
+                        headlineContent = { Text(text = item.toString()) },
+                        leadingContent = {
+                            val iconSize = Dimensions.xlarge
+                            if (item == value) {
+                                CheckIcon(
+                                    modifier = Modifier.size(iconSize)
+                                )
+                            } else {
+                                Box(Modifier.size(iconSize))
+                            }
+                        },
+                        modifier = Modifier.clickable {
+                            onSelected(item)
+                            scope.launch { sheetState.hide() }.invokeOnCompletion {
+                                isSelectorOpen = false
+                            }
                         }
-                    },
-                    modifier = Modifier.clickable {
-                        onSelected(item)
-                        scope.launch { sheetState.hide() }.invokeOnCompletion {
-                            isSelectorOpen = false
-                        }
-                    }
-                )
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

Updates Material3 to v1.1.1 and add `LazyColumn` to options in setting, so it can be scrolled safely

<!-- Describe what your PR does here, change log, etc -->

## Related Issues

- Closes #80

## Progress

- [x] update Material
- [x] add LazyColumn to Settings

### Pull request checklist

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [ ] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Test modal opening on both screen orientations, check if all selectable content is clickable and able to be visible  

<!-- Describe how the reviewers can test your feature. -->

## Visual reference


https://github.com/profusion/android-enhanced-video-player/assets/9094028/efac70ed-aa4c-426e-a1a9-11ddc84aa28e


