### PR TITLE
Replace `org.jlleitschuh.gradle.ktlint` with `org.jmailen.kotlinter`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 root = true
 
 [*.{kt,kts}]
-#Custom configuration
-ktlint_disabled_rules = no-wildcard-imports
+ktlint_code_style=android_studio
 insert_final_newline = true
+ktlint_standard_max-line-length = disabled
+ktlint_standard_no-wildcard-imports = disabled

--- a/app/src/main/java/com/example/androidenhancedvideoplayer/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/androidenhancedvideoplayer/ui/theme/Theme.kt
@@ -34,7 +34,7 @@ private val LightColorScheme = lightColorScheme(
     onTertiary = Color.White,
     onBackground = Color(0xFF1C1B1F),
     onSurface = Color(0xFF1C1B1F),
-    */
+     */
 )
 
 @Composable

--- a/app/src/main/java/com/example/androidenhancedvideoplayer/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/androidenhancedvideoplayer/ui/theme/Type.kt
@@ -30,5 +30,5 @@ val Typography = Typography(
         lineHeight = 16.sp,
         letterSpacing = 0.5.sp
     )
-    */
+     */
 )

--- a/build.gradle
+++ b/build.gradle
@@ -14,22 +14,15 @@ plugins {
     id 'com.android.application' version '8.0.1' apply false
     id 'com.android.library' version '8.0.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.21' apply false
-    id 'org.jlleitschuh.gradle.ktlint' version "11.3.2"
+    id 'org.jmailen.kotlinter' version '3.15.0'
 }
 
 subprojects {
-    apply plugin: 'org.jlleitschuh.gradle.ktlint'
+    apply plugin: 'org.jmailen.kotlinter'
 }
 
-ktlint {
-    version = "0.46.1"
-    debug = true
-    verbose = true
-    android = true
-    outputToConsole = true
-    outputColorName = "RED"
+kotlinter {
     ignoreFailures = false
-    enableExperimentalRules = true
 }
 
 task clean(type: Delete) {

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -40,12 +40,10 @@ $ yarn install
 This will install husky pre-commit, pre-push and msg-commit hooks.
 
 ### Install Ktlint to IDE
-Make sure to open this project with Android Studio at least once before proceeding with ktlint instalation. That guarantees some hidden files/folders (like `.idea`) exist and can be configured by the following command. Navigate to the project’s directory in the terminal and execute:
-```console
-ktlint applyToIDEAProject
-```
 
-This will change Android Studio's code format configurations. The next time you apply an automatic code formatting on a kotlin file, it will use our new set of rules defined by ktlint.
+To ensure code quality, the project utilizes [kotlinter](https://github.com/jeremymailen/kotlinter-gradle) for linting. The linting process is automatically triggered through commit and push hooks. However, you can also perform manual linting by running the commands `yarn lint` and `yarn lint-fix`.
+
+For a seamless integration with Android Studio and to conveniently view and fix linting errors within the IDE, we highly recommend installing the [ktlint-intellij-plugin](https://plugins.jetbrains.com/plugin/15057-ktlint-unofficial-). This plugin allows you to directly display and handle linting errors from within Android Studio.
 
 **Pro Tip:** use a hotkey to make Android Studio format your file for you. You can choose your hotkey on `File > Settings > Keymap > Main Menu > Code > Reformat Code & Reformat File`
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "test": "./gradlew test",
-    "lint": "./gradlew ktlintCheck",
-    "lint-fix": "./gradlew ktlintFormat",
+    "lint": "./gradlew lintKotlin",
+    "lint-fix": "./gradlew formatKotlin",
     "pre-push": "run-p lint test",
     "prepare": "husky install"
   },


### PR DESCRIPTION
## Description

- This change aims to align the gradle plugin with what is used in the Android Studio plugin, so the lint command will be synchronized with what is shown on the IDE
- It also fixes all the lint errors that were being ignored by the previous plugin

### Pull request checklist

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

- Run `yarn lint` and `yarn lint-fix`
- Also try to trigger some git hook